### PR TITLE
feat: シンプルなkyawaランディングページを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Kyawa</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Welcome to Kyawa</h1>
+            <p class="subtitle">AIと創造の実験場</p>
+        </header>
+        
+        <main class="main-content">
+            <section class="intro">
+                <p>新しい技術と創造性が出会う場所です。</p>
+                <p>ここで、AIと人間の創造力を組み合わせた実験を行います。</p>
+            </section>
+        </main>
+        
+        <footer class="footer">
+            <p>&copy; 2024 Kyawa. All rights reserved.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,142 @@
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    background-color: #f5f5f5; /* 薄いグレーの背景 */
+    color: #333; /* 黒い文字 */
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.container {
+    max-width: 800px;
+    width: 90%;
+    margin: 0 auto;
+    padding: 2rem;
+    text-align: center;
+}
+
+/* Header styles */
+.header {
+    margin-bottom: 3rem;
+}
+
+.title {
+    font-size: 3rem;
+    font-weight: 300;
+    margin-bottom: 1rem;
+    color: #222;
+    letter-spacing: 2px;
+}
+
+.subtitle {
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: #555;
+    margin-bottom: 2rem;
+}
+
+/* Main content */
+.main-content {
+    margin-bottom: 3rem;
+}
+
+.intro {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.intro p {
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
+    color: #444;
+    line-height: 1.8;
+}
+
+/* Footer */
+.footer {
+    border-top: 1px solid #ddd;
+    padding-top: 2rem;
+    margin-top: 2rem;
+}
+
+.footer p {
+    font-size: 0.9rem;
+    color: #777;
+}
+
+/* レスポンシブデザイン */
+
+/* タブレット */
+@media screen and (max-width: 768px) {
+    .container {
+        width: 95%;
+        padding: 1.5rem;
+    }
+    
+    .title {
+        font-size: 2.5rem;
+    }
+    
+    .subtitle {
+        font-size: 1.3rem;
+    }
+    
+    .intro p {
+        font-size: 1rem;
+    }
+}
+
+/* スマートフォン */
+@media screen and (max-width: 480px) {
+    .container {
+        width: 95%;
+        padding: 1rem;
+    }
+    
+    .title {
+        font-size: 2rem;
+        letter-spacing: 1px;
+    }
+    
+    .subtitle {
+        font-size: 1.1rem;
+        margin-bottom: 1.5rem;
+    }
+    
+    .header {
+        margin-bottom: 2rem;
+    }
+    
+    .main-content {
+        margin-bottom: 2rem;
+    }
+    
+    .intro p {
+        font-size: 0.95rem;
+        margin-bottom: 1.2rem;
+    }
+}
+
+/* 超小型デバイス */
+@media screen and (max-width: 320px) {
+    .title {
+        font-size: 1.8rem;
+    }
+    
+    .subtitle {
+        font-size: 1rem;
+    }
+    
+    .intro p {
+        font-size: 0.9rem;
+    }
+}


### PR DESCRIPTION
## 概要
Kyawaのシンプルなランディングページを追加しました。AIと創造をテーマにした紹介ページです。

## 変更内容
- `index.html`: タイトル「Welcome to Kyawa」、サブタイトル「AIと創造の実験場」を含む構造
- `style.css`: レスポンシブ対応（320px / 480px / 768px）、カラーコード：背景 #f5f5f5、文字色 #333
- セマンティックなHTML構造
- フレックスボックスによる中央配置、タイポグラフィ調整

## 備考
- Claude Sonnet 4 によって自動生成されたコード
- `genspark_ai_developer` ブランチからの初回PR
